### PR TITLE
Fixed the installer and "commend" interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ A GUI application based on [warp-cli](https://developers.cloudflare.com/warp-cli
 
 ## Installation
 
-Read the [warp-cli install](https://developers.cloudflare.com/warp-client/get-started/linux) documentation. Install `warp-cli` and
-register with the `$ warp-cli register` command.
+Read the [warp-cli install](https://developers.cloudflare.com/warp-client/get-started/linux) documentation. Install `warp-cli` and register with the `$ warp-cli registration new` command. Ensure you test your connection and accept any TOS notices by trying `$ warp-cli connect` and then `$ warp-cli disconnect`.
 
 Then execute the following commands:
 
     $ git clone https://github.com/mrmoein/warp-cloudflare-gui
     $ cd warp-cloudflare-gui
-    $ python3 install.py
+    $ bash install.sh
     $ sudo chmod +x ~/.local/share/applications/warp-gui.desktop
 
 Now search for `warp cloudflare` in your desktop menu.
@@ -29,7 +28,7 @@ Now search for `warp cloudflare` in your desktop menu.
 ## Hidden Mode
 If you only want to use the tray icon, you can run the program in hidden mode.
     
-    $ python ./main.py --hide
+    $ bash main.sh --hide
 
 ## Uninstall
 

--- a/install.py
+++ b/install.py
@@ -16,11 +16,12 @@ file.write('''[Desktop Entry]
 Name=Warp Cloudflare 
 Version=1.0
 Comment=A gui app base on warp-cli for linux
-Exec=python3 {}/main.py
+Exec=bash {}/main.sh
 Icon=warp_gui
 Terminal=false
+Path={}
 Type=Application
-'''.format(cur_path))
+'''.format(cur_path, cur_path))
 print('Desktop file created at "{}"'.format(desktop_file))
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python3 -m venv venv
+
+source venv/bin/activate
+python3 install.py "$@"
+deactivate

--- a/main.sh
+++ b/main.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source venv/bin/activate
+python3 main.py "$@"
+deactivate

--- a/warp_gui/commend.py
+++ b/warp_gui/commend.py
@@ -15,7 +15,7 @@ class Commend:
         return False
 
     def account_type(self):
-        result = self.run('warp-cli account')
+        result = self.run('warp-cli registration show')
         try:
             data = result.split('\n')
             result = data[0].split(': ')
@@ -39,7 +39,7 @@ class Commend:
         return ''
 
     def set_mode(self, mode):
-        result = self.run('warp-cli set-mode {}'.format(mode))
+        result = self.run('warp-cli mode {}'.format(mode))
         if result == 'Success':
             return True
         return False


### PR DESCRIPTION
The installer wasn't compatible with most recent distros as they manage their python packages externally system-wide, so pip is usually disabled and discouraged outside virtual environments, so I updated the installer and main program by wrapping them in a bash script that handles a python virtual environment. I also updated the desktop file generation code to account for this.

Additionally, CloudFlare must have updated their command syntax so I made a few adjustments to the "commend" interface to account for this and it seems to be fine now.

Issues this should (help) address:
- #29
- #27