### PR TITLE
ensure script runs from its own directory

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+cd "$(dirname "$0")"
 source venv/bin/activate
 python3 main.py "$@"
 deactivate


### PR DESCRIPTION
navigate to script directory before trying to activate venv to fix issues when calling script from outside its own directory
otherwise calling ie 
"`bash ~/warp-cloudflare-gui/main.sh`" from the terminal if outside the scripts directory would result in:

```
/home/torkel/warp-cloudflare-gui/main.sh: line 4: venv/bin/activate: No such file or directory
python3: can't open file '/home/torkel/main.py': [Errno 2] No such file or directory
/home/torkel/warp-cloudflare-gui/main.sh: line 6: deactivate: command not found
```