### PR TITLE
Add high DPI scaling support in GUI initialization

### DIFF
--- a/warp_gui/mainwindow.py
+++ b/warp_gui/mainwindow.py
@@ -14,6 +14,10 @@ from warp_gui.ui.mainwindow_ui import Ui_MainWindow
 
 class GUI:
     def __init__(self):
+        if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
+            QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+        if hasattr(QtCore.Qt, 'AA_UseHighDpiPixmaps'):
+            QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
         self.app = QtWidgets.QApplication(sys.argv)
         self.app.setApplicationName('Cloudflare Warp')
         self.mainWindow = QtWidgets.QMainWindow()


### PR DESCRIPTION
Enable high DPI scaling attributes for the application.
Not sure if `def __init__` is best for setting QApplication attributes. If you know better place, please fix my changes.

Current:
<img width="250" height="414" alt="Screenshot from 2025-12-12 21-15-58" src="https://github.com/user-attachments/assets/40a06a9c-80da-4870-9eaa-7541fa12b88d" />

With HiDPI fix:
<img width="500" height="764" alt="Screenshot from 2025-12-12 21-15-21" src="https://github.com/user-attachments/assets/b044e389-33ab-4d39-91e1-6900c8fc47df" />
